### PR TITLE
Fixed CMake error: forgot to find boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ find_package(pomerol)
 message(STATUS "Pomerol includes : ${pomerol_INCLUDE_DIRS}")
 message(STATUS "Pomerol libraries : ${pomerol_LIBRARIES}")
 
+find_package(Boost COMPONENTS mpi serialization)
+
 include_directories(${pomerol_INCLUDE_DIRS})
 include_directories(include)
 

--- a/src/ReadWrite.cpp
+++ b/src/ReadWrite.cpp
@@ -33,7 +33,13 @@ bool ReadDataFile::read_line() {
         while( std::getline(ss, word, ' ') ){
             words.push_back(word);
         }
-        assert( words.size() == n_index + n_val );
+        if ( words.size() != n_index + n_val ) {
+		std::cerr << "words.size() != n_index + n_val" << std::endl;
+		std::cerr << "words.size(): " << words.size() << std::endl;
+		std::cerr << "n_index: " << n_index << std::endl;
+		std::cerr << "n_val: " << n_val << std::endl;
+		exit(1);
+	}
         // set indices
         for(int i=0; i<n_index; i++){
             indices[i] = std::stoi(words[i]);

--- a/src/pomerol2dcore.cpp
+++ b/src/pomerol2dcore.cpp
@@ -151,7 +151,7 @@ void ThreeFreq::push_back(int wb, int wf1, int wf2)
 // assign val to melem with casting the type of val
 void cast_melem(std::complex<double> val, double &melem)
 {
-    if (imag(val) > 1.0e-14){
+    if (imag(val) > 1.0e-10){
         std::cerr << "ERROR: COMPLEX MATRIX ELEMENT"
                   << std::endl
                   << "The solver accepts only real values for matrix elements. "
@@ -306,6 +306,7 @@ int main(int argc, char* argv[])
     // set H_0
     {
         ReadDataFile rdf(prms.file_h0, 2, 2);
+	std::cout << "Reading " << prms.file_h0 << "... " << std::endl;
         while( rdf.read_line() ){
             std::string site1 = converter[rdf.get_index(0)].site;
             unsigned short s1 = converter[rdf.get_index(0)].spn;
@@ -319,6 +320,7 @@ int main(int argc, char* argv[])
             // c^+_{i1,o1,s1} c_{i2,o2,s2}
             L.addTerm(OneBodyTerm(site1, site2, melem, o1, o2, s1, s2));
         }
+	std::cout << "Done" << std::endl << std::endl;
     }
 
     // set U_{ijkl}


### PR DESCRIPTION
Fixed CMake error on Ubuntu 20.04 LTS